### PR TITLE
Fix admin retry and AI cost attribution

### DIFF
--- a/src/main/java/dev/maboullaite/fhemni/analysis/AnalysisService.java
+++ b/src/main/java/dev/maboullaite/fhemni/analysis/AnalysisService.java
@@ -300,29 +300,38 @@ public class AnalysisService {
         }
     }
 
-    private void analyze(AnalysisSession session, Reservation reservation) {
-        AiUsage consumedUsage = AiUsage.empty();
+    private void analyze(AnalysisSession session, Reservation analysisReservation) {
+        Reservation factCheckReservation = null;
+        AiUsage analysisUsage = AiUsage.empty();
+        AiUsage factCheckUsage = AiUsage.empty();
         try {
             AnalysisSnapshot input = session.snapshot();
             publish(session, AnalysisStatus.ANALYZING, 12, "Gemini is exploring the video timeline");
             GatewayAnalysisResult analysis = gateway.analyze(
                     input.videoUrl(), input.videoId(), input.language());
-            consumedUsage = AiUsage.empty().plus(analysis.usage());
+            analysisUsage = analysis.usage();
+            usageGuard.succeeded(analysisReservation, analysisUsage);
+            analysisReservation = null;
 
             publish(session, AnalysisStatus.FACT_CHECKING, 68, "Checking factual claims against external evidence");
+            if (gateway.live() && analysis.report().claims().stream()
+                    .anyMatch(claim -> claim.kind() == ClaimKind.FACT)) {
+                factCheckReservation = usageGuard.reserveFactCheck(input.id(), gateway.factCheckModel());
+            }
             GatewayFactCheckResult factChecks = gateway.factCheck(
                     analysis.report().claims(), input.language());
-            consumedUsage = consumedUsage.plus(factChecks.usage());
+            factCheckUsage = factChecks.usage();
+            usageGuard.succeeded(factCheckReservation, factCheckUsage);
+            factCheckReservation = null;
             VideoReport report = analysis.report().withClaims(
                     mergeAssessments(analysis.report().claims(), factChecks.assessments()));
 
             revisions.complete(input.id(), report, analysis.interactionId());
             session.complete(report, analysis.interactionId());
-            usageGuard.succeeded(reservation, consumedUsage);
-            reservation = null;
             eventHub.publish(input.id(), new AnalysisEvent(AnalysisStatus.COMPLETED, 100, "Analysis complete"));
         } catch (RuntimeException exception) {
-            usageGuard.failed(reservation, consumedUsage);
+            usageGuard.failed(analysisReservation, analysisUsage);
+            usageGuard.failed(factCheckReservation, factCheckUsage);
             log.warn("Analysis failed: {}", exception.getMessage());
             String message = friendlyError(exception);
             session.fail(message);

--- a/src/main/java/dev/maboullaite/fhemni/catalog/CatalogBatchAnalysisService.java
+++ b/src/main/java/dev/maboullaite/fhemni/catalog/CatalogBatchAnalysisService.java
@@ -71,7 +71,7 @@ public class CatalogBatchAnalysisService {
                 created.complete();
             } else {
                 try {
-                    executor.execute(() -> process(created, pending));
+                    executor.execute(() -> process(created, pending, latestByVideo));
                 } catch (RuntimeException exception) {
                     created.fail("The catalogue batch worker is unavailable. Please retry later.");
                     throw exception;
@@ -91,11 +91,17 @@ public class CatalogBatchAnalysisService {
         return revision == null || revision.status() == AnalysisStatus.FAILED;
     }
 
-    private void process(BatchRun run, List<CatalogVideo> videos) {
+    private void process(
+            BatchRun run,
+            List<CatalogVideo> videos,
+            Map<String, RevisionSummary> latestByVideo) {
         try {
             for (CatalogVideo video : videos) {
                 run.begin(video.title());
-                AnalysisSnapshot analysis = analyses.create(video.canonicalUrl(), run.language().code());
+                RevisionSummary previous = latestByVideo.get(video.youtubeVideoId());
+                AnalysisSnapshot analysis = previous != null && previous.status() == AnalysisStatus.FAILED
+                        ? analyses.reprocess(video.canonicalUrl(), run.language().code())
+                        : analyses.create(video.canonicalUrl(), run.language().code());
                 run.analysisStarted(analysis.id());
                 AnalysisSnapshot terminal = awaitTerminal(analysis);
                 if (terminal.status() == AnalysisStatus.FAILED) {

--- a/src/main/java/dev/maboullaite/fhemni/cost/AiOperation.java
+++ b/src/main/java/dev/maboullaite/fhemni/cost/AiOperation.java
@@ -2,6 +2,7 @@ package dev.maboullaite.fhemni.cost;
 
 public enum AiOperation {
     ANALYSIS,
+    FACT_CHECK,
     CHAT_VIDEO,
     CHAT_CHECK
 }

--- a/src/main/java/dev/maboullaite/fhemni/cost/AiUsageGuard.java
+++ b/src/main/java/dev/maboullaite/fhemni/cost/AiUsageGuard.java
@@ -73,6 +73,11 @@ public class AiUsageGuard {
         }
     }
 
+    public Reservation reserveFactCheck(UUID analysisId, String model) {
+        return new Reservation(repository.reserve(
+                AiOperation.FACT_CHECK, null, analysisId, model, clock.instant()));
+    }
+
     public Reservation reserveQuestion(UUID analysisId, UUID userId, AiOperation operation, String model) {
         if (!chatEnabled) {
             throw new AiBudgetExceededException("Video chat is disabled until the owner enables its production budget.");

--- a/src/main/resources/db/migration/V13__separate_fact_check_usage.sql
+++ b/src/main/resources/db/migration/V13__separate_fact_check_usage.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ai_usage_events DROP CONSTRAINT ai_usage_operation_check;
+
+ALTER TABLE ai_usage_events
+    ADD CONSTRAINT ai_usage_operation_check
+    CHECK (operation IN ('ANALYSIS', 'FACT_CHECK', 'CHAT_VIDEO', 'CHAT_CHECK'));

--- a/src/main/resources/static/js/admin.js
+++ b/src/main/resources/static/js/admin.js
@@ -147,11 +147,14 @@
 
             const analyze = document.createElement('button');
             analyze.type = 'button';
-            const forceReprocess = video.latestAnalysisStatus === 'COMPLETED';
-            analyze.className = forceReprocess
+            const hasPreviousAttempt = Boolean(video.latestAnalysisId);
+            const forceReprocess = hasPreviousAttempt;
+            analyze.className = video.latestAnalysisStatus === 'COMPLETED'
                 ? 'secondary-button admin-analyze-button'
                 : 'primary-button admin-analyze-button';
-            analyze.textContent = t(forceReprocess ? 'admin.reprocessAnalysis' : 'admin.runAnalysis');
+            analyze.textContent = t(video.latestAnalysisStatus === 'COMPLETED'
+                ? 'admin.reprocessAnalysis'
+                : 'admin.runAnalysis');
             analyze.disabled = batchRunning || !analysisAvailable;
             if (!analysisAvailable) analyze.title = t('admin.analysisUnavailable');
             analyze.addEventListener('click', () => launchAnalysis(
@@ -179,7 +182,8 @@
             showFeedback(t('admin.analysisUnavailable'), true);
             return;
         }
-        if (forceReprocess && !window.confirm(t('admin.confirmReprocess', {
+        if (forceReprocess && video.latestAnalysisStatus === 'COMPLETED'
+                && !window.confirm(t('admin.confirmReprocess', {
             language: outputLanguage.selectedOptions[0]?.textContent || outputLanguage.value
         }))) return;
         const originalLabel = analyzeButton.textContent;

--- a/src/test/java/dev/maboullaite/fhemni/analysis/AnalysisPartialUsageTest.java
+++ b/src/test/java/dev/maboullaite/fhemni/analysis/AnalysisPartialUsageTest.java
@@ -24,6 +24,8 @@ import dev.maboullaite.fhemni.gemini.GeminiApiException;
 import dev.maboullaite.fhemni.gemini.VideoIntelligenceGateway;
 import dev.maboullaite.fhemni.model.AnalysisSnapshot;
 import dev.maboullaite.fhemni.model.AnalysisStatus;
+import dev.maboullaite.fhemni.model.Claim;
+import dev.maboullaite.fhemni.model.ClaimKind;
 import dev.maboullaite.fhemni.model.VideoReport;
 import dev.maboullaite.fhemni.video.YouTubeUrlParser;
 import org.junit.jupiter.api.Test;
@@ -37,10 +39,14 @@ class AnalysisPartialUsageTest {
         ExecutorService executor = mock(ExecutorService.class);
         AiUsageGuard usageGuard = mock(AiUsageGuard.class);
         AnalysisRevisionRepository revisions = mock(AnalysisRevisionRepository.class);
-        Reservation reservation = new Reservation(UUID.randomUUID());
+        Reservation analysisReservation = new Reservation(UUID.randomUUID());
+        Reservation factCheckReservation = new Reservation(UUID.randomUUID());
         AiUsage analysisUsage = new AiUsage(3_200, 1_100, 400, 90, 0, 0);
+        Claim factualClaim = new Claim(
+                "claim-1", "A factual statement", "Speaker", 30,
+                ClaimKind.FACT, null, null, null, List.of());
         VideoReport report = new VideoReport(
-                "Report", "Summary", "Details", List.of(), List.of(), List.of(), List.of());
+                "Report", "Summary", "Details", List.of(), List.of(), List.of(factualClaim), List.of());
 
         when(gateway.live()).thenReturn(true);
         when(gateway.model()).thenReturn("analysis-model");
@@ -50,7 +56,8 @@ class AnalysisPartialUsageTest {
         when(revisions.findReusable(
                 anyString(), any(), anyString(), anyString(), anyString(), anyString(), eq(false)))
                 .thenReturn(Optional.empty());
-        when(usageGuard.reserveAnalysis(any(), eq("analysis-model"))).thenReturn(reservation);
+        when(usageGuard.reserveAnalysis(any(), eq("analysis-model"))).thenReturn(analysisReservation);
+        when(usageGuard.reserveFactCheck(any(), eq("fact-model"))).thenReturn(factCheckReservation);
         when(gateway.analyze(anyString(), anyString(), any()))
                 .thenReturn(new GatewayAnalysisResult("interaction", report, analysisUsage));
         when(gateway.factCheck(any(), any()))
@@ -69,6 +76,7 @@ class AnalysisPartialUsageTest {
         AnalysisSnapshot result = service.create("https://youtu.be/n5B3boj2MFM", "ary");
 
         assertThat(result.status()).isEqualTo(AnalysisStatus.FAILED);
-        verify(usageGuard).failed(reservation, analysisUsage);
+        verify(usageGuard).succeeded(analysisReservation, analysisUsage);
+        verify(usageGuard).failed(factCheckReservation, AiUsage.empty());
     }
 }

--- a/src/test/java/dev/maboullaite/fhemni/catalog/CatalogBatchAnalysisServiceTest.java
+++ b/src/test/java/dev/maboullaite/fhemni/catalog/CatalogBatchAnalysisServiceTest.java
@@ -61,6 +61,35 @@ class CatalogBatchAnalysisServiceTest {
         verify(analyses, never()).create(eq(completedVideo.canonicalUrl()), any());
     }
 
+    @Test
+    void forceReprocessesTheLatestFailedEpisode() {
+        CatalogVideoRepository catalog = mock(CatalogVideoRepository.class);
+        AnalysisRevisionRepository revisions = mock(AnalysisRevisionRepository.class);
+        AnalysisService analyses = mock(AnalysisService.class);
+        ExecutorService executor = mock(ExecutorService.class);
+        CatalogVideo failedVideo = video("TMgYfNkfF14", "Failed episode");
+        when(catalog.findAll(500)).thenReturn(List.of(failedVideo));
+        when(revisions.latestByVideo()).thenReturn(Map.of(
+                failedVideo.youtubeVideoId(),
+                new RevisionSummary(
+                        UUID.randomUUID(), failedVideo.youtubeVideoId(), OutputLanguage.DARIJA,
+                        AnalysisStatus.FAILED, Instant.now(), false)));
+        when(analyses.reprocess(eq(failedVideo.canonicalUrl()), eq("ary")))
+                .thenReturn(completedAnalysis(failedVideo));
+
+        CatalogBatchAnalysisService service = new CatalogBatchAnalysisService(
+                catalog, revisions, analyses, executor, Duration.ofMinutes(30));
+        ArgumentCaptor<Runnable> work = ArgumentCaptor.forClass(Runnable.class);
+
+        service.start("ary", 20);
+        verify(executor).execute(work.capture());
+        work.getValue().run();
+
+        assertEquals(BatchState.COMPLETED, service.latest().state());
+        verify(analyses).reprocess(failedVideo.canonicalUrl(), "ary");
+        verify(analyses, never()).create(eq(failedVideo.canonicalUrl()), any());
+    }
+
     private CatalogVideo video(String youtubeId, String title) {
         Instant now = Instant.now();
         return new CatalogVideo(

--- a/src/test/java/dev/maboullaite/fhemni/cost/AiUsageGuardIntegrationTest.java
+++ b/src/test/java/dev/maboullaite/fhemni/cost/AiUsageGuardIntegrationTest.java
@@ -36,6 +36,8 @@ class AiUsageGuardIntegrationTest {
         UUID firstAnalysis = UUID.randomUUID();
         var first = guard.reserveAnalysis(firstAnalysis, "test-model");
         guard.succeeded(first, new AiUsage(100, 20, 40, 5, 0, 2));
+        var factCheck = guard.reserveFactCheck(firstAnalysis, "fact-check-model");
+        guard.succeeded(factCheck, new AiUsage(80, 10, 0, 0, 0, 1));
         guard.reserveAnalysis(UUID.randomUUID(), "test-model");
 
         assertThatThrownBy(() -> guard.reserveAnalysis(UUID.randomUUID(), "test-model"))
@@ -45,6 +47,9 @@ class AiUsageGuardIntegrationTest {
                 .param("id", first.id()).query(String.class).single()).isEqualTo("SUCCEEDED");
         assertThat(jdbc.sql("SELECT input_tokens FROM ai_usage_events WHERE id = :id")
                 .param("id", first.id()).query(Integer.class).single()).isEqualTo(100);
+        assertThat(jdbc.sql("SELECT operation || ':' || model FROM ai_usage_events WHERE id = :id")
+                .param("id", factCheck.id()).query(String.class).single())
+                .isEqualTo("FACT_CHECK:fact-check-model");
 
         var user = users.recordLogin(new ExternalIdentityProfile(
                 "test", "cost-user", null, "Cost User", null, false, null), false);


### PR DESCRIPTION
## Summary
- record video analysis and fact-check usage as separate per-model events
- force retries after failed single and batch analyses so completed revisions are not silently reused

## Validation
- adds focused tests for partial usage accounting, per-model events, and failed batch retries
- local diff checks pass
- Java 26 suite runs in CI

The deployment-only admin CSV-role resolver is kept in the private operations folder and is intentionally not part of this public-source PR.