### PR TITLE
Default the site to Darija

### DIFF
--- a/src/main/resources/static/admin.html
+++ b/src/main/resources/static/admin.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="fhemni">
+<html lang="ar" dir="rtl" data-theme="fhemni">
 <head>
     <script src="/js/analytics.js"></script>
     <meta charset="utf-8">
@@ -88,6 +88,6 @@
     </section>
 </main>
 
-<script src="/js/i18n.js?v=20260906-9" defer></script><script src="/js/auth.js" defer></script><script src="/js/catalog-ui.js?v=20260906-2" defer></script><script src="/js/admin.js?v=20260906-8" defer></script>
+<script src="/js/i18n.js?v=20260906-13" defer></script><script src="/js/auth.js" defer></script><script src="/js/catalog-ui.js?v=20260906-2" defer></script><script src="/js/admin.js?v=20260906-8" defer></script>
 </body>
 </html>

--- a/src/main/resources/static/analysis.html
+++ b/src/main/resources/static/analysis.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="fhemni">
+<html lang="ar" dir="rtl" data-theme="fhemni">
 <head>
     <script src="/js/analytics.js"></script>
     <meta charset="utf-8">
@@ -200,7 +200,7 @@
     <a class="footer-feedback-link" href="https://github.com/aboullaite/fhemni/issues" target="_blank" rel="noopener noreferrer" data-i18n="common.suggestFeature">Suggest a feature</a>
 </footer>
 
-<script src="/js/i18n.js?v=20260906-11" defer></script>
+<script src="/js/i18n.js?v=20260906-13" defer></script>
 <script src="/js/auth.js" defer></script>
 <script src="/js/analysis.js?v=20260906-4" defer></script>
 </body>

--- a/src/main/resources/static/community.html
+++ b/src/main/resources/static/community.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="fhemni">
+<html lang="ar" dir="rtl" data-theme="fhemni">
 <head>
     <script src="/js/analytics.js"></script>
     <meta charset="utf-8">
@@ -72,6 +72,6 @@
 </main>
 
 <footer><img class="footer-logo" src="/assets/brand/fhemni-logo.png" alt="Fhemni — فهّمني"><span data-i18n="common.footer">© 2026 Mohammed Aboullaite</span><a class="footer-feedback-link" href="https://github.com/aboullaite/fhemni/issues" target="_blank" rel="noopener noreferrer" data-i18n="common.suggestFeature">Suggest a feature</a></footer>
-<script src="/js/i18n.js?v=20260906-12" defer></script><script src="/js/auth.js" defer></script><script src="/js/catalog-ui.js?v=20260906-2" defer></script><script src="/js/suggestions.js?v=20260906-5" defer></script>
+<script src="/js/i18n.js?v=20260906-13" defer></script><script src="/js/auth.js" defer></script><script src="/js/catalog-ui.js?v=20260906-2" defer></script><script src="/js/suggestions.js?v=20260906-5" defer></script>
 </body>
 </html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="fhemni">
+<html lang="ar" dir="rtl" data-theme="fhemni">
 <head>
     <script src="/js/analytics.js"></script>
     <meta charset="utf-8">
@@ -86,7 +86,7 @@
     <a class="footer-feedback-link" href="https://github.com/aboullaite/fhemni/issues" target="_blank" rel="noopener noreferrer" data-i18n="common.suggestFeature">Suggest a feature</a>
 </footer>
 
-<script src="/js/i18n.js?v=20260906-11" defer></script>
+<script src="/js/i18n.js?v=20260906-13" defer></script>
 <script src="/js/auth.js" defer></script>
 <script src="/js/catalog-ui.js" defer></script>
 <script src="/js/landing.js" defer></script>

--- a/src/main/resources/static/js/i18n.js
+++ b/src/main/resources/static/js/i18n.js
@@ -989,9 +989,7 @@
         } catch (_) { /* storage can be disabled */ }
         if (SUPPORTED.includes(stored)) return stored;
 
-        const preferred = navigator.languages?.[0] || navigator.language || 'en';
-        const base = preferred.toLowerCase().split('-')[0];
-        return SUPPORTED.includes(base) ? base : 'en';
+        return 'ar';
     }
 
     function translate(key, parameters = {}) {

--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="fhemni">
+<html lang="ar" dir="rtl" data-theme="fhemni">
 <head>
     <script src="/js/analytics.js"></script>
     <meta charset="utf-8">
@@ -42,7 +42,7 @@
     </section>
 </main>
 
-<script src="/js/i18n.js?v=20260906-11" defer></script>
+<script src="/js/i18n.js?v=20260906-13" defer></script>
 <script src="/js/auth.js" defer></script>
 <script src="/js/login.js" defer></script>
 </body>

--- a/src/main/resources/static/video.html
+++ b/src/main/resources/static/video.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="fhemni">
+<html lang="ar" dir="rtl" data-theme="fhemni">
 <head>
     <script src="/js/analytics.js"></script>
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
@@ -26,6 +26,6 @@
     <section id="videoError" class="catalog-error detail-loading" hidden></section>
 </main>
 <footer><img class="footer-logo" src="/assets/brand/fhemni-logo.png" alt="Fhemni — فهّمني"><span data-i18n="common.footer">© 2026 Mohammed Aboullaite</span><a class="footer-feedback-link" href="https://github.com/aboullaite/fhemni/issues" target="_blank" rel="noopener noreferrer" data-i18n="common.suggestFeature">Suggest a feature</a></footer>
-<script src="/js/i18n.js?v=20260906-11" defer></script><script src="/js/auth.js" defer></script><script src="/js/catalog-ui.js?v=20260906-2" defer></script><script src="/js/video.js?v=20260906-3" defer></script>
+<script src="/js/i18n.js?v=20260906-13" defer></script><script src="/js/auth.js" defer></script><script src="/js/catalog-ui.js?v=20260906-2" defer></script><script src="/js/video.js?v=20260906-3" defer></script>
 </body>
 </html>

--- a/src/main/resources/static/videos.html
+++ b/src/main/resources/static/videos.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="fhemni">
+<html lang="ar" dir="rtl" data-theme="fhemni">
 <head>
     <script src="/js/analytics.js"></script>
     <meta charset="utf-8">
@@ -72,6 +72,6 @@
 </main>
 
 <footer><img class="footer-logo" src="/assets/brand/fhemni-logo.png" alt="Fhemni — فهّمني"><span data-i18n="common.footer">© 2026 Mohammed Aboullaite</span><a class="footer-feedback-link" href="https://github.com/aboullaite/fhemni/issues" target="_blank" rel="noopener noreferrer" data-i18n="common.suggestFeature">Suggest a feature</a></footer>
-<script src="/js/i18n.js?v=20260906-12" defer></script><script src="/js/auth.js" defer></script><script src="/js/catalog-ui.js?v=20260906-2" defer></script><script src="/js/suggestions.js?v=20260906-5" defer></script><script src="/js/catalog.js" defer></script>
+<script src="/js/i18n.js?v=20260906-13" defer></script><script src="/js/auth.js" defer></script><script src="/js/catalog-ui.js?v=20260906-2" defer></script><script src="/js/suggestions.js?v=20260906-5" defer></script><script src="/js/catalog.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Sets Darija as the first-visit default, preserves explicit language choices in local storage, initializes every page in RTL, and refreshes the i18n asset version. Java 26 verification and gitleaks passed in CI; browser behavior was verified across navigation.