### PR TITLE
Localize verdict prose

### DIFF
--- a/src/main/java/dev/maboullaite/fhemni/programme/PartyProgrammeService.java
+++ b/src/main/java/dev/maboullaite/fhemni/programme/PartyProgrammeService.java
@@ -223,10 +223,10 @@ public class PartyProgrammeService {
                 .toList();
         PromiseAssessment assessment = new PromiseAssessment(
                 UUID.randomUUID(), promiseId, repository.nextAssessmentRevision(promiseId), HORIZON_YEARS,
-                draft.verdict(), localized(draft.summary(), "Assessment summary", 30_000),
-                localized(draft.requirements(), "Requirements", 30_000),
-                localized(draft.assumptions(), "Assumptions", 50_000),
-                localized(draft.calculationNotes(), "Calculation notes", 50_000),
+                draft.verdict(), assessmentText(draft.summary(), "Assessment summary", 30_000),
+                assessmentText(draft.requirements(), "Requirements", 30_000),
+                assessmentText(draft.assumptions(), "Assumptions", 50_000),
+                assessmentText(draft.calculationNotes(), "Calculation notes", 50_000),
                 required(draft.methodologyVersion(), "Methodology version", 40),
                 providerMode(draft.providerMode()), text(draft.modelNames(), 300),
                 draft.dataCutoff(), EditorialStatus.DRAFT, Instant.now(), null, evidence);
@@ -459,6 +459,38 @@ public class PartyProgrammeService {
                 required(value.ar(), field + " (Darija)", maxLength),
                 required(value.fr(), field + " (French)", maxLength),
                 required(value.en(), field + " (English)", maxLength));
+    }
+
+    private static LocalizedText assessmentText(LocalizedText value, String field, int maxLength) {
+        if (value == null) {
+            return localized(null, field, maxLength);
+        }
+        return localized(new LocalizedText(
+                naturalizeVerdictCodes(
+                        value.ar(), "قابل للتحقيق", "صعيب التحقيق فـ5 سنين",
+                        "بعيد بزاف يتحقق فـ5 سنين", "المعطيات ما كافياش"),
+                naturalizeVerdictCodes(
+                        value.fr(), "réalisable", "difficile à réaliser en cinq ans",
+                        "très improbable en cinq ans", "données insuffisantes"),
+                naturalizeVerdictCodes(
+                        value.en(), "achievable", "difficult to achieve within five years",
+                        "very unlikely within five years", "insufficient data")), field, maxLength);
+    }
+
+    private static String naturalizeVerdictCodes(
+            String value,
+            String possible,
+            String hard,
+            String notAchievable,
+            String insufficientData) {
+        if (value == null) {
+            return null;
+        }
+        return value
+                .replace("NOT_ACHIEVABLE", notAchievable)
+                .replace("INSUFFICIENT_DATA", insufficientData)
+                .replace("POSSIBLE", possible)
+                .replace("HARD", hard);
     }
 
     private static String required(String value, String field, int maxLength) {

--- a/src/main/resources/db/migration/V25__localize_assessment_verdict_prose.sql
+++ b/src/main/resources/db/migration/V25__localize_assessment_verdict_prose.sql
@@ -1,0 +1,75 @@
+-- Provider verdict enums belong in the structured verdict column and must not
+-- leak into reader-facing prose. Preserve meaning while naturalizing any
+-- previously stored uppercase enum tokens in each localized text field.
+
+UPDATE promise_assessments
+SET summary_ar = REPLACE(summary_ar, 'POSSIBLE', 'قابل للتحقيق'),
+    requirements_ar = REPLACE(requirements_ar, 'POSSIBLE', 'قابل للتحقيق'),
+    assumptions_ar = REPLACE(assumptions_ar, 'POSSIBLE', 'قابل للتحقيق'),
+    calculation_notes_ar = REPLACE(calculation_notes_ar, 'POSSIBLE', 'قابل للتحقيق');
+
+UPDATE promise_assessments
+SET summary_ar = REPLACE(summary_ar, 'HARD', 'صعيب التحقيق فـ5 سنين'),
+    requirements_ar = REPLACE(requirements_ar, 'HARD', 'صعيب التحقيق فـ5 سنين'),
+    assumptions_ar = REPLACE(assumptions_ar, 'HARD', 'صعيب التحقيق فـ5 سنين'),
+    calculation_notes_ar = REPLACE(calculation_notes_ar, 'HARD', 'صعيب التحقيق فـ5 سنين');
+
+UPDATE promise_assessments
+SET summary_ar = REPLACE(summary_ar, 'NOT_ACHIEVABLE', 'بعيد بزاف يتحقق فـ5 سنين'),
+    requirements_ar = REPLACE(requirements_ar, 'NOT_ACHIEVABLE', 'بعيد بزاف يتحقق فـ5 سنين'),
+    assumptions_ar = REPLACE(assumptions_ar, 'NOT_ACHIEVABLE', 'بعيد بزاف يتحقق فـ5 سنين'),
+    calculation_notes_ar = REPLACE(calculation_notes_ar, 'NOT_ACHIEVABLE', 'بعيد بزاف يتحقق فـ5 سنين');
+
+UPDATE promise_assessments
+SET summary_ar = REPLACE(summary_ar, 'INSUFFICIENT_DATA', 'المعطيات ما كافياش'),
+    requirements_ar = REPLACE(requirements_ar, 'INSUFFICIENT_DATA', 'المعطيات ما كافياش'),
+    assumptions_ar = REPLACE(assumptions_ar, 'INSUFFICIENT_DATA', 'المعطيات ما كافياش'),
+    calculation_notes_ar = REPLACE(calculation_notes_ar, 'INSUFFICIENT_DATA', 'المعطيات ما كافياش');
+
+UPDATE promise_assessments
+SET summary_fr = REPLACE(summary_fr, 'POSSIBLE', 'réalisable'),
+    requirements_fr = REPLACE(requirements_fr, 'POSSIBLE', 'réalisable'),
+    assumptions_fr = REPLACE(assumptions_fr, 'POSSIBLE', 'réalisable'),
+    calculation_notes_fr = REPLACE(calculation_notes_fr, 'POSSIBLE', 'réalisable');
+
+UPDATE promise_assessments
+SET summary_fr = REPLACE(summary_fr, 'HARD', 'difficile à réaliser en cinq ans'),
+    requirements_fr = REPLACE(requirements_fr, 'HARD', 'difficile à réaliser en cinq ans'),
+    assumptions_fr = REPLACE(assumptions_fr, 'HARD', 'difficile à réaliser en cinq ans'),
+    calculation_notes_fr = REPLACE(calculation_notes_fr, 'HARD', 'difficile à réaliser en cinq ans');
+
+UPDATE promise_assessments
+SET summary_fr = REPLACE(summary_fr, 'NOT_ACHIEVABLE', 'très improbable en cinq ans'),
+    requirements_fr = REPLACE(requirements_fr, 'NOT_ACHIEVABLE', 'très improbable en cinq ans'),
+    assumptions_fr = REPLACE(assumptions_fr, 'NOT_ACHIEVABLE', 'très improbable en cinq ans'),
+    calculation_notes_fr = REPLACE(calculation_notes_fr, 'NOT_ACHIEVABLE', 'très improbable en cinq ans');
+
+UPDATE promise_assessments
+SET summary_fr = REPLACE(summary_fr, 'INSUFFICIENT_DATA', 'données insuffisantes'),
+    requirements_fr = REPLACE(requirements_fr, 'INSUFFICIENT_DATA', 'données insuffisantes'),
+    assumptions_fr = REPLACE(assumptions_fr, 'INSUFFICIENT_DATA', 'données insuffisantes'),
+    calculation_notes_fr = REPLACE(calculation_notes_fr, 'INSUFFICIENT_DATA', 'données insuffisantes');
+
+UPDATE promise_assessments
+SET summary_en = REPLACE(summary_en, 'POSSIBLE', 'achievable'),
+    requirements_en = REPLACE(requirements_en, 'POSSIBLE', 'achievable'),
+    assumptions_en = REPLACE(assumptions_en, 'POSSIBLE', 'achievable'),
+    calculation_notes_en = REPLACE(calculation_notes_en, 'POSSIBLE', 'achievable');
+
+UPDATE promise_assessments
+SET summary_en = REPLACE(summary_en, 'HARD', 'difficult to achieve within five years'),
+    requirements_en = REPLACE(requirements_en, 'HARD', 'difficult to achieve within five years'),
+    assumptions_en = REPLACE(assumptions_en, 'HARD', 'difficult to achieve within five years'),
+    calculation_notes_en = REPLACE(calculation_notes_en, 'HARD', 'difficult to achieve within five years');
+
+UPDATE promise_assessments
+SET summary_en = REPLACE(summary_en, 'NOT_ACHIEVABLE', 'very unlikely within five years'),
+    requirements_en = REPLACE(requirements_en, 'NOT_ACHIEVABLE', 'very unlikely within five years'),
+    assumptions_en = REPLACE(assumptions_en, 'NOT_ACHIEVABLE', 'very unlikely within five years'),
+    calculation_notes_en = REPLACE(calculation_notes_en, 'NOT_ACHIEVABLE', 'very unlikely within five years');
+
+UPDATE promise_assessments
+SET summary_en = REPLACE(summary_en, 'INSUFFICIENT_DATA', 'insufficient data'),
+    requirements_en = REPLACE(requirements_en, 'INSUFFICIENT_DATA', 'insufficient data'),
+    assumptions_en = REPLACE(assumptions_en, 'INSUFFICIENT_DATA', 'insufficient data'),
+    calculation_notes_en = REPLACE(calculation_notes_en, 'INSUFFICIENT_DATA', 'insufficient data');

--- a/src/main/resources/static/js/promise.js
+++ b/src/main/resources/static/js/promise.js
@@ -103,7 +103,7 @@
 
     function cleanSummary(value) {
         return String(value || '')
-            .replace(/\b(?:POSSIBLE|HARD|NOT_ACHIEVABLE|INSUFFICIENT_DATA)\b[.:؛،-]?/gi, '')
+            .replace(/\b(?:POSSIBLE|HARD|NOT_ACHIEVABLE|INSUFFICIENT_DATA)\b[.:؛،-]?/g, '')
             .replace(/[ \t]+([.,؛،])/g, '$1')
             .replace(/[ \t]{2,}/g, ' ')
             .trim();

--- a/src/test/java/dev/maboullaite/fhemni/web/ProgrammeIntegrationTest.java
+++ b/src/test/java/dev/maboullaite/fhemni/web/ProgrammeIntegrationTest.java
@@ -91,8 +91,8 @@ class ProgrammeIntegrationTest {
                 "The programme states an aggregate envelope."));
         var assessment = programmes.createAssessment(promise.promise().id(), new DraftAssessment(
                 FeasibilityVerdict.HARD,
-                localized("ممكن ولكن صعيب", "Possible, mais difficile", "Possible, but hard"),
-                localized("خاص نمو قوي", "Une croissance forte est nécessaire", "Strong growth is required"),
+                localized("HARD. ممكن ولكن صعيب", "C’est POSSIBLE, mais difficile", "HARD. Possible, but hard"),
+                localized("خاص نمو قوي", "Une croissance forte est nécessaire", "INSUFFICIENT_DATA without a baseline"),
                 localized("النتيجة كتبدل مع النمو", "Le résultat dépend de la croissance", "The result depends on growth"),
                 localized("200 ألف منصب فالسنة", "200 000 emplois par an", "200,000 jobs per year"),
                 "fhemni-feasibility-v1",
@@ -103,6 +103,11 @@ class ProgrammeIntegrationTest {
                         "https://www.hcp.ma/",
                         LocalDate.of(2026, 8, 1),
                         "Official baseline for employment."))));
+
+        assertThat(assessment.summary().ar()).startsWith("صعيب التحقيق فـ5 سنين.");
+        assertThat(assessment.summary().fr()).startsWith("C’est réalisable");
+        assertThat(assessment.summary().en()).startsWith("difficult to achieve within five years.");
+        assertThat(assessment.requirements().en()).startsWith("insufficient data");
 
         assertThatThrownBy(() -> programmes.publishProgramme(programme.id()))
                 .isInstanceOf(IllegalStateException.class);


### PR DESCRIPTION
Fix internal feasibility enum codes leaking into reader-facing programme assessment prose.\n\n- normalizes future Gemini/OpenAI assessment text before persistence\n- migrates existing localized summaries, requirements, assumptions, and calculation notes\n- preserves legitimate lowercase words such as ‘possible’ in client rendering\n- adds integration coverage\n\nValidation: 147 tests passing.