### PR TITLE
Keep How it works navigation consistent

### DIFF
--- a/src/main/resources/static/admin-episodes.html
+++ b/src/main/resources/static/admin-episodes.html
@@ -10,7 +10,7 @@
 <div class="ambient ambient-one"></div><div class="ambient ambient-two"></div>
 <header class="site-header public-header">
     <a class="brand" href="/" aria-label="Fhemni home" data-i18n-aria-label="common.brandHome"><img class="brand-logo brand-logo-full" src="/assets/brand/fhemni-logo.png" alt="Fhemni"><img class="brand-logo brand-logo-icon" src="/assets/brand/fhemni-icon.png" alt="Fhemni"></a>
-    <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation"><a href="/videos" data-i18n="common.catalogue">Catalogue</a><a href="/parties" data-i18n="common.parties">Parties</a></nav>
+    <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation"><a href="/videos" data-i18n="common.catalogue">Catalogue</a><a href="/parties" data-i18n="common.parties">Parties</a><a href="/#how-it-works" data-i18n="common.howItWorks">How it works</a></nav>
     <div class="header-actions"><label class="site-language"><span class="sr-only" data-i18n="common.siteLanguage">Website language</span><select data-site-language data-i18n-aria-label="common.siteLanguage" aria-label="Website language"><option value="en">EN</option><option value="fr">FR</option><option value="ar">الدارجة</option></select></label><div id="authNav"></div></div>
 </header>
 <main class="admin-dashboard">

--- a/src/main/resources/static/admin-people.html
+++ b/src/main/resources/static/admin-people.html
@@ -10,7 +10,7 @@
 <div class="ambient ambient-one"></div><div class="ambient ambient-two"></div>
 <header class="site-header public-header">
     <a class="brand" href="/" aria-label="Fhemni home" data-i18n-aria-label="common.brandHome"><img class="brand-logo brand-logo-full" src="/assets/brand/fhemni-logo.png" alt="Fhemni"><img class="brand-logo brand-logo-icon" src="/assets/brand/fhemni-icon.png" alt="Fhemni"></a>
-    <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation"><a href="/videos" data-i18n="common.catalogue">Catalogue</a><a href="/parties" data-i18n="common.parties">Parties</a></nav>
+    <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation"><a href="/videos" data-i18n="common.catalogue">Catalogue</a><a href="/parties" data-i18n="common.parties">Parties</a><a href="/#how-it-works" data-i18n="common.howItWorks">How it works</a></nav>
     <div class="header-actions"><label class="site-language"><span class="sr-only" data-i18n="common.siteLanguage">Website language</span><select data-site-language data-i18n-aria-label="common.siteLanguage" aria-label="Website language"><option value="en">EN</option><option value="fr">FR</option><option value="ar">الدارجة</option></select></label><div id="authNav"></div></div>
 </header>
 <main class="admin-dashboard">

--- a/src/main/resources/static/admin-programmes.html
+++ b/src/main/resources/static/admin-programmes.html
@@ -10,7 +10,7 @@
 <div class="ambient ambient-one"></div><div class="ambient ambient-two"></div>
 <header class="site-header public-header">
     <a class="brand" href="/" aria-label="Fhemni home" data-i18n-aria-label="common.brandHome"><img class="brand-logo brand-logo-full" src="/assets/brand/fhemni-logo.png" alt="Fhemni"><img class="brand-logo brand-logo-icon" src="/assets/brand/fhemni-icon.png" alt="Fhemni"></a>
-    <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation"><a href="/videos" data-i18n="common.catalogue">Catalogue</a><a href="/parties" data-i18n="common.parties">Parties</a></nav>
+    <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation"><a href="/videos" data-i18n="common.catalogue">Catalogue</a><a href="/parties" data-i18n="common.parties">Parties</a><a href="/#how-it-works" data-i18n="common.howItWorks">How it works</a></nav>
     <div class="header-actions"><label class="site-language"><span class="sr-only" data-i18n="common.siteLanguage">Website language</span><select data-site-language data-i18n-aria-label="common.siteLanguage" aria-label="Website language"><option value="en">EN</option><option value="fr">FR</option><option value="ar">الدارجة</option></select></label><div id="authNav"></div></div>
 </header>
 <main class="admin-dashboard">

--- a/src/main/resources/static/admin-suggestions.html
+++ b/src/main/resources/static/admin-suggestions.html
@@ -10,7 +10,7 @@
 <div class="ambient ambient-one"></div><div class="ambient ambient-two"></div>
 <header class="site-header public-header">
     <a class="brand" href="/" aria-label="Fhemni home" data-i18n-aria-label="common.brandHome"><img class="brand-logo brand-logo-full" src="/assets/brand/fhemni-logo.png" alt="Fhemni"><img class="brand-logo brand-logo-icon" src="/assets/brand/fhemni-icon.png" alt="Fhemni"></a>
-    <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation"><a href="/videos" data-i18n="common.catalogue">Catalogue</a><a href="/parties" data-i18n="common.parties">Parties</a></nav>
+    <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation"><a href="/videos" data-i18n="common.catalogue">Catalogue</a><a href="/parties" data-i18n="common.parties">Parties</a><a href="/#how-it-works" data-i18n="common.howItWorks">How it works</a></nav>
     <div class="header-actions"><label class="site-language"><span class="sr-only" data-i18n="common.siteLanguage">Website language</span><select data-site-language data-i18n-aria-label="common.siteLanguage" aria-label="Website language"><option value="en">EN</option><option value="fr">FR</option><option value="ar">الدارجة</option></select></label><div id="authNav"></div></div>
 </header>
 <main class="admin-dashboard">

--- a/src/main/resources/static/admin.html
+++ b/src/main/resources/static/admin.html
@@ -14,7 +14,7 @@
 
 <header class="site-header public-header">
     <a class="brand" href="/" aria-label="Fhemni home" data-i18n-aria-label="common.brandHome"><img class="brand-logo brand-logo-full" src="/assets/brand/fhemni-logo.png" alt="Fhemni"><img class="brand-logo brand-logo-icon" src="/assets/brand/fhemni-icon.png" alt="Fhemni"></a>
-    <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation"><a href="/videos" data-i18n="common.catalogue">Catalogue</a><a href="/parties" data-i18n="common.parties">Parties</a></nav>
+    <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation"><a href="/videos" data-i18n="common.catalogue">Catalogue</a><a href="/parties" data-i18n="common.parties">Parties</a><a href="/#how-it-works" data-i18n="common.howItWorks">How it works</a></nav>
     <div class="header-actions"><label class="site-language"><span class="sr-only" data-i18n="common.siteLanguage">Website language</span><select data-site-language data-i18n-aria-label="common.siteLanguage" aria-label="Website language"><option value="en">EN</option><option value="fr">FR</option><option value="ar">الدارجة</option></select></label><div id="authNav"></div></div>
 </header>
 

--- a/src/main/resources/static/methodology.html
+++ b/src/main/resources/static/methodology.html
@@ -14,7 +14,7 @@
 
 <header class="site-header public-header">
     <a class="brand" href="/" aria-label="Fhemni home" data-i18n-aria-label="common.brandHome"><img class="brand-logo brand-logo-full" src="/assets/brand/fhemni-logo.png" alt=""><img class="brand-logo brand-logo-icon" src="/assets/brand/fhemni-icon.png" alt=""></a>
-    <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation"><a href="/videos" data-i18n="common.catalogue">Catalogue</a><a href="/parties" data-i18n="common.parties">Parties</a></nav>
+    <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation"><a href="/videos" data-i18n="common.catalogue">Catalogue</a><a href="/parties" data-i18n="common.parties">Parties</a><a href="/#how-it-works" data-i18n="common.howItWorks">How it works</a></nav>
     <div class="header-actions"><label class="site-language"><span class="sr-only" data-i18n="common.siteLanguage">Website language</span><select data-site-language data-i18n-aria-label="common.siteLanguage" aria-label="Website language"><option value="en">EN</option><option value="fr">FR</option><option value="ar">الدارجة</option></select></label><div id="authNav"></div></div>
 </header>
 

--- a/src/main/resources/static/parties.html
+++ b/src/main/resources/static/parties.html
@@ -21,6 +21,7 @@
     <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation">
         <a href="/videos" data-i18n="common.catalogue">Catalogue</a>
         <a class="active" href="/parties" data-i18n="common.parties">Parties</a>
+        <a href="/#how-it-works" data-i18n="common.howItWorks">How it works</a>
     </nav>
     <div class="header-actions">
         <label class="site-language"><span class="sr-only" data-i18n="common.siteLanguage">Website language</span><select data-site-language data-i18n-aria-label="common.siteLanguage" aria-label="Website language"><option value="en">EN</option><option value="fr">FR</option><option value="ar">الدارجة</option></select></label>

--- a/src/main/resources/static/party.html
+++ b/src/main/resources/static/party.html
@@ -21,6 +21,7 @@
     <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation">
         <a href="/videos" data-i18n="common.catalogue">Catalogue</a>
         <a class="active" href="/parties" data-i18n="common.parties">Parties</a>
+        <a href="/#how-it-works" data-i18n="common.howItWorks">How it works</a>
     </nav>
     <div class="header-actions">
         <label class="site-language"><span class="sr-only" data-i18n="common.siteLanguage">Website language</span><select data-site-language data-i18n-aria-label="common.siteLanguage" aria-label="Website language"><option value="en">EN</option><option value="fr">FR</option><option value="ar">الدارجة</option></select></label>

--- a/src/main/resources/static/person.html
+++ b/src/main/resources/static/person.html
@@ -21,6 +21,7 @@
     <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation">
         <a href="/videos" data-i18n="common.catalogue">Catalogue</a>
         <a class="active" href="/parties" data-i18n="common.parties">Parties</a>
+        <a href="/#how-it-works" data-i18n="common.howItWorks">How it works</a>
     </nav>
     <div class="header-actions">
         <label class="site-language"><span class="sr-only" data-i18n="common.siteLanguage">Website language</span><select data-site-language data-i18n-aria-label="common.siteLanguage" aria-label="Website language"><option value="en">EN</option><option value="fr">FR</option><option value="ar">الدارجة</option></select></label>

--- a/src/main/resources/static/promise.html
+++ b/src/main/resources/static/promise.html
@@ -14,7 +14,7 @@
 
 <header class="site-header public-header">
     <a class="brand" href="/" aria-label="Fhemni home" data-i18n-aria-label="common.brandHome"><img class="brand-logo brand-logo-full" src="/assets/brand/fhemni-logo.png" alt=""><img class="brand-logo brand-logo-icon" src="/assets/brand/fhemni-icon.png" alt=""></a>
-    <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation"><a href="/videos" data-i18n="common.catalogue">Catalogue</a><a class="active" href="/parties" data-i18n="common.parties">Parties</a></nav>
+    <nav class="primary-nav" aria-label="Primary navigation" data-i18n-aria-label="common.primaryNavigation"><a href="/videos" data-i18n="common.catalogue">Catalogue</a><a class="active" href="/parties" data-i18n="common.parties">Parties</a><a href="/#how-it-works" data-i18n="common.howItWorks">How it works</a></nav>
     <div class="header-actions"><label class="site-language"><span class="sr-only" data-i18n="common.siteLanguage">Website language</span><select data-site-language data-i18n-aria-label="common.siteLanguage" aria-label="Website language"><option value="en">EN</option><option value="fr">FR</option><option value="ar">الدارجة</option></select></label><div id="authNav"></div></div>
 </header>
 

--- a/src/test/java/dev/maboullaite/fhemni/web/NavigationConsistencyTest.java
+++ b/src/test/java/dev/maboullaite/fhemni/web/NavigationConsistencyTest.java
@@ -1,0 +1,44 @@
+package dev.maboullaite.fhemni.web;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+class NavigationConsistencyTest {
+
+    private static final List<String> SECONDARY_PAGES = List.of(
+            "admin.html",
+            "admin-episodes.html",
+            "admin-people.html",
+            "admin-programmes.html",
+            "admin-suggestions.html",
+            "community.html",
+            "methodology.html",
+            "parties.html",
+            "party.html",
+            "person.html",
+            "promise.html",
+            "video.html",
+            "videos.html");
+
+    @Test
+    void everyPrimaryNavigationLinksToHowItWorks() throws IOException {
+        assertThat(html("index.html"))
+                .contains("href=\"#how-it-works\" data-i18n=\"common.howItWorks\"");
+
+        for (String page : SECONDARY_PAGES) {
+            assertThat(html(page))
+                    .as("primary navigation in %s", page)
+                    .contains("href=\"/#how-it-works\" data-i18n=\"common.howItWorks\"");
+        }
+    }
+
+    private String html(String page) throws IOException {
+        return new ClassPathResource("static/" + page).getContentAsString(UTF_8);
+    }
+}


### PR DESCRIPTION
Adds the existing How it works destination to every primary header that was missing it. The homepage keeps its local anchor; all other pages link back to /#how-it-works. Includes a regression test covering all 14 primary-navigation page shells.\n\nValidation: NavigationConsistencyTest passes on Java 26; HTML diff check is clean.