### PR TITLE
Fix GCS signed media URL dates

### DIFF
--- a/src/main/java/dev/maboullaite/fhemni/programme/media/GcsProgrammeMediaStorage.java
+++ b/src/main/java/dev/maboullaite/fhemni/programme/media/GcsProgrammeMediaStorage.java
@@ -102,7 +102,7 @@ public class GcsProgrammeMediaStorage implements ProgrammeMediaStorage {
             Instant now = Instant.now();
             String timestamp = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'")
                     .withZone(ZoneOffset.UTC).format(now);
-            String date = DateTimeFormatter.BASIC_ISO_DATE.withZone(ZoneOffset.UTC).format(now);
+            String date = DateTimeFormatter.ofPattern("yyyyMMdd").withZone(ZoneOffset.UTC).format(now);
             String scope = date + "/auto/storage/goog4_request";
             String canonicalPath = "/" + encodePath(bucket) + "/" + encodePath(requiredObjectKey(objectKey));
             String query = "X-Goog-Algorithm=GOOG4-RSA-SHA256"

--- a/src/test/java/dev/maboullaite/fhemni/programme/media/GcsProgrammeMediaStorageTest.java
+++ b/src/test/java/dev/maboullaite/fhemni/programme/media/GcsProgrammeMediaStorageTest.java
@@ -52,6 +52,9 @@ class GcsProgrammeMediaStorageTest {
                 .contains("X-Goog-Expires=3600")
                 .contains("X-Goog-SignedHeaders=host")
                 .doesNotContain("PRIVATE KEY", "test-key");
+        assertThat(url).containsPattern("X-Goog-Credential=[^&]+%2F\\d{8}%2Fauto%2Fstorage%2Fgoog4_request");
+        assertThat(url).containsPattern("X-Goog-Date=\\d{8}T\\d{6}Z");
+        assertThat(url).doesNotContainPattern("X-Goog-Credential=[^&]+%2F\\d{8}Z%2F");
         String signature = url.substring(url.indexOf("X-Goog-Signature=") + "X-Goog-Signature=".length());
         assertThat(signature).matches("[0-9a-f]{512}");
     }


### PR DESCRIPTION
## Summary
- format the V4 signing credential scope as an eight-digit UTC date
- cover the credential scope and request timestamp shapes in the signing test

## Why
Service-account signing exposed a production-only formatting issue: `BASIC_ISO_DATE` included a trailing `Z`, which GCS rejects because it no longer matches `X-Goog-Date`.

## Verification
- focused GCS storage test passes
- full suite passes: 218 tests, 0 failures