### PR TITLE
Verify font CSP on browser GET responses

### DIFF
--- a/scripts/verify-web-fonts.sh
+++ b/scripts/verify-web-fonts.sh
@@ -46,9 +46,8 @@ if [ -n "${FHEMNI_SITE_URL:-}" ]; then
     css_ref=$(sed -n 's/.*href="\([^"]*\/css\/dist\.css?v=[^"]*\)".*/\1/p' \
         "$project_root/src/main/resources/static/index.html" | head -n 1)
     curl --fail --silent --show-error --location --retry 3 --connect-timeout 5 --max-time 20 \
+        --dump-header "$check_dir/live.headers" \
         "$site_url/" --output "$check_dir/live.html"
-    curl --fail --silent --show-error --head --retry 3 --connect-timeout 5 --max-time 20 \
-        "$site_url/" --output "$check_dir/live.headers"
     if ! grep -Eiq '^content-security-policy:.*font-src[^;]*https://storage\.googleapis\.com' \
         "$check_dir/live.headers"; then
         echo "Live Content-Security-Policy does not allow GCS fonts" >&2


### PR DESCRIPTION
## Summary
- capture CSP headers from the same browser-equivalent GET that downloads the live page
- remove the redundant HEAD request whose static-resource response omits Spring Security headers

## Verification
- shell syntax passes
- pinned GCS font checks pass
- corrected guard passes against the healthy inactive production slot on port 8081
- live traffic remains on the previous green slot